### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: rust
 rust:
   - stable
+
+script:
+  # Only run tests when environment variables are available, because they will fail otherwise.
+  # For details, see https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions.
+  - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then cargo test --verbose fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ rust:
 script:
   # Only run tests when environment variables are available, because they will fail otherwise.
   # For details, see https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions.
-  - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then cargo test --verbose fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then cargo test --verbose; else echo "Tests do not run on PRs for security reasons."; fi'


### PR DESCRIPTION
PRs fail, because of [security restrictions](https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions). Don't run the dependent tests on PRs.