### PR TITLE
Build all targets (incl. examples) on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ rust:
   - stable
 
 install:
-  - cargo build --verbose
+  - cargo build --verbose --all-targets
   - rustup component add rustfmt
 
 script:
   - cargo fmt -- --check
   # Only run tests when environment variables are available, because they will fail otherwise.
   # For details, see https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions.
-  - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then cargo test --verbose; else echo "Tests do not run on PRs for security reasons."; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then cargo test --verbose --all-targets; else echo "Tests do not run on PRs for security reasons."; fi'


### PR DESCRIPTION
I noticed that the examples in #15 passed CI, although they do not compile. I'm not sure whether this is necessary, but I included [all targets](https://doc.rust-lang.org/cargo/commands/cargo-build.html) (bins, examples, tests, benches). Now, if any of those fail to build or test, the CI fails.

If targeting all was too much, it will result in longer build times. The alternative is passing builds that should fail. So in my opinion (especially since right now this costs nothing), we should target all, until we need to change it.